### PR TITLE
Fix extracting HDR save data for multiple profiles.

### DIFF
--- a/competitive-smash-decker.sh
+++ b/competitive-smash-decker.sh
@@ -281,8 +281,10 @@ Choice=$(main_menu)
 				echo "# Downloading save data..."
 				sleep 1
 				wget https://github.com/the-outcaster/competitive-smash-decker/raw/main/100_save_data-1.zip
-				SAVE_FOLDER=$(find $HOME/.local/share/yuzu/nand/user/save/0000000000000000/*/ -mindepth 1 -maxdepth 1 -type d | sed -n '2p') # get the second directory
-				unzip -o -q 100_save_data-1.zip -d $SAVE_FOLDER
+				PROFILE_FOLDER="$HOME/.local/share/yuzu/nand/user/save/0000000000000000"
+				for d in "$PROFILE_FOLDER"/*; do
+					unzip -o -q 100_save_data-1.zip -d "$d/01006A800016E000"
+				done
 				rm 100_save_data-1.zip
 
 				echo "70"


### PR DESCRIPTION
Iterate over each profile in the main yuzu profile folder and unzip the save file to each one.